### PR TITLE
feat: add initial tasks to download nodejs toolchain

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,1 +1,4 @@
 ---
+nodejs_toolchain_dest: /opt
+nodejs_toolchain_version: ""
+nodejs_toolchain_url: https://s3.amazonaws.com/boxes.10gen.com/build/node-{{ nodejs_toolchain_version }}-{{ distro }}-x64.tar.gz

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,4 +1,10 @@
 ---
+dependencies:
+  - role: ansible-role-toolchain
+    toolchain_creates_directory: "{{ nodejs_toolchain_dest }}/node"
+    toolchain_dest: "{{ nodejs_toolchain_dest }}"
+    toolchain_list_files: true
+    toolchain_url: "{{ nodejs_toolchain_url }}"
 galaxy_info:
   author: MongoDB
   description: Installs NodeJS toolchain

--- a/molecule/default/playbook.yml
+++ b/molecule/default/playbook.yml
@@ -4,3 +4,5 @@
   hosts: all
   roles:
     - role: ansible-role-nodejs
+      vars:
+        nodejs_toolchain_version: v8.11.3

--- a/molecule/default/requirements.yml
+++ b/molecule/default/requirements.yml
@@ -1,2 +1,4 @@
 ---
-[]
+- name: ansible-role-toolchain
+  src: git+https://github.com/mongodb-ansible-roles/ansible-role-toolchain.git
+  version: directory_name

--- a/molecule/default/tests/test_default.rb
+++ b/molecule/default/tests/test_default.rb
@@ -1,1 +1,25 @@
 # frozen_string_literal: true
+
+describe command('/opt/node/bin/node --version') do
+  its('stdout') { should eq "v8.11.3\n" }
+end
+
+describe command('node --version') do
+  its('stdout') { should eq "v8.11.3\n" }
+end
+
+describe command('/opt/node/bin/npm --version') do
+  its('stdout') { should eq "5.6.0\n" }
+end
+
+describe command('npm --version') do
+  its('stdout') { should eq "5.6.0\n" }
+end
+
+describe command('/opt/node/bin/npx --version') do
+  its('stdout') { should eq "9.7.1\n" }
+end
+
+describe command('npx --version') do
+  its('stdout') { should eq "9.7.1\n" }
+end

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,1 +1,3 @@
 ---
+- include_tasks: setup-Debian.yml
+  when: ansible_os_family == "Debian"

--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -1,0 +1,24 @@
+---
+- name: Rename nodejs directory
+  command: mv {{ nodejs_toolchain_dest }}/{{ toolchain_top_level_directory }} {{ nodejs_toolchain_dest }}/node
+  args:
+    creates: "{{ nodejs_toolchain_dest }}/node"
+  when: toolchain_top_level_directory is defined
+
+- name: Create node symlink
+  file:
+    src: "{{ nodejs_toolchain_dest }}/node/bin/node"
+    dest: /usr/local/bin/node
+    state: link
+
+- name: Create npm symlink
+  file:
+    src: "{{ nodejs_toolchain_dest }}/node/bin/npm"
+    dest: /usr/local/bin/npm
+    state: link
+
+- name: Create npx symlink
+  file:
+    src: "{{ nodejs_toolchain_dest }}/node/bin/npx"
+    dest: /usr/local/bin/npx
+    state: link

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,1 +1,7 @@
 ---
+distro_dict:
+  Debian: linux
+distro: "{{ distro_dict[ansible_os_family] }}"
+architecture_dict:
+  x86_64: amd64
+architecture: "{{ architecture_dict[ansible_architecture] }}"


### PR DESCRIPTION
### Description

This PR add in the toolchain role in the meta dependencies. The toolchain role takes parameters from this role and downloads the nodejs toolchain. This role then sets up the proper symlinks for the nodejs binaries on the hosts. 

### Testing

```
make test
```
