### PR TITLE
feat: variable for setting artifactory base url

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,4 +1,5 @@
 ---
+nodejs_toolchain_artifactory_base_url: https://artifactory.corp.mongodb.com
 nodejs_toolchain_final_dest: /opt/node
 nodejs_toolchain_npmrc_dest: "~{{ nodejs_toolchain_user }}/.npmrc"
 nodejs_toolchain_version: ""

--- a/templates/npmrc.j2
+++ b/templates/npmrc.j2
@@ -1,1 +1,1 @@
-registry=https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/
+registry={{ nodejs_toolchain_artifactory_base_url }}/artifactory/api/npm/npm/


### PR DESCRIPTION
### Description

Add parameter to set base artifactory url that could be overwritten in order to change artifactory instance for a specific distro.
It is added so we could configure other than production artifactory instance. We would need this changes to test our staging environment that right now has production data. We want to ensure that data and configuration were  transferred correctly from Artifactory 6.x to Artifactory 7.x instances

